### PR TITLE
Bump ks-devops chart version from 0.0.4 to 0.1.1

### DIFF
--- a/charts/ks-devops/Chart.yaml
+++ b/charts/ks-devops/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
We can do a release after this PR and #4 

fix https://github.com/kubesphere-sigs/ks-devops-helm-chart/issues/2