### PR TITLE
Convert GC logging Flags to xlog

### DIFF
--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -34,27 +34,22 @@ Master:
     -Dhudson.model.LoadStatistics.clock=5000
     -Dhudson.model.LoadStatistics.decay=0.2
     -Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000
+    -Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true
     -Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=10000
     -verbose:gc
     -Xloggc:/var/jenkins_home/gc-%t.log
-    -XX:NumberOfGCLogFiles=2
-    -XX:+UseGCLogFileRotation
-    -XX:GCLogFileSize=100m
-    -XX:+PrintGC
-    -XX:+PrintGCDateStamps
-    -XX:+PrintGCDetails
-    -XX:+PrintHeapAtGC
-    -XX:+PrintGCCause
-    -XX:+PrintTenuringDistribution
-    -XX:+PrintReferenceGC
-    -XX:+PrintAdaptiveSizePolicy
+    -Xlog:gc
+    -Xlog:gc*
+    -Xlog:gc+heap=trace
+    -Xlog:age*=trace
+    -Xlog:ref*=debug
+    -Xlog:ergo*=trace
     -XX:+UseG1GC
     -XX:+UseStringDeduplication
     -XX:+ParallelRefProcEnabled
     -XX:+DisableExplicitGC
     -XX:+UnlockDiagnosticVMOptions
     -XX:+UnlockExperimentalVMOptions
-    -Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true
   ServicePort: 80
   ServiceType: NodePort
   NodePort: 30180


### PR DESCRIPTION
readme details from https://docs.oracle.com/javase/9/tools/java.htm#GUID-BE93ABDC-999C-4CB5-A88B-1994
AAAC74D5__CONVERTGCLOGGINGFLAGSTOXLOG-A5046BD1

This PR can the JVM flag issue on the Java. But I prefer don't merge this PR until we get release v3.2. Because the Jenkins image still is using java8 in the ks-devops v3.2 

fix https://github.com/kubesphere-sigs/ks-devops-helm-chart/issues/19

/hold