### PR TITLE
Add PipelineRun GC condition support

### DIFF
--- a/charts/ks-devops/templates/cronjob-gc.yaml
+++ b/charts/ks-devops/templates/cronjob-gc.yaml
@@ -29,7 +29,7 @@ spec:
               args:
                 - "--max-count={{ .Values.gcJobs.maxCount }}"
                 - "--max-age={{ .Values.gcJobs.maxAge }}"
-                - "--condition=or"
+                - "--condition=ignoreTime"
               name: "pipeline-run-gc"
               resources: {}
               terminationMessagePath: /dev/termination-log

--- a/charts/ks-devops/templates/cronjob-gc.yaml
+++ b/charts/ks-devops/templates/cronjob-gc.yaml
@@ -29,6 +29,7 @@ spec:
               args:
                 - "--max-count={{ .Values.gcJobs.maxCount }}"
                 - "--max-age={{ .Values.gcJobs.maxAge }}"
+                - "--condition=or"
               name: "pipeline-run-gc"
               resources: {}
               terminationMessagePath: /dev/termination-log

--- a/charts/ks-devops/values.yaml
+++ b/charts/ks-devops/values.yaml
@@ -18,7 +18,7 @@ gcJobs:
   # gcJobs.maxAge -- Max age from which `PipelineRun`s will be deleted
   maxAge: 168h
   # gcJobs.maxCount -- Max count from which `PipelineRun`s will be deleted
-  maxCount: 10
+  maxCount: 30
   # gcJobs.schedule -- Cron expression to periodically delete `PipelineRun`s
   schedule: "0/30 * * * *"
   # gcJobs.failedJobsHistoryLimit -- Drives the failed jobs history limit


### PR DESCRIPTION
Before this PR, it is possible to have too many PipelineRuns during 168h. In order to avoid too many data to let etcd panic, I brought this change.

Now, the GC will collect if there are more than 30 or older than 168h.

We need a release once the upstream https://github.com/kubesphere-sigs/ks/pull/219 get merged.
