### PR TITLE
Reformat yaml config item in pod template

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -300,70 +300,11 @@ data:
                       fsGroup: 1000
 
               - name: "go16"
-                namespace: "{{ .Values.Agent.WorkerNamespace }}"
                 label: "go16"
-                nodeUsageMode: "EXCLUSIVE"
-                idleMinutes: 0
+                inheritFrom: "go"
                 containers:
                 - name: "go"
                   image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.golang16.image }}:{{ .Values.Agent.Builder.golang16.tag }}{{ template "jenkins.agent.variant" . }}"
-                  command: "cat"
-                  args: ""
-                  ttyEnabled: true
-                  privileged: {{ template "jenkins.agent.privileged" . }}
-                  resourceRequestCpu: "100m"
-                  resourceLimitCpu: "4000m"
-                  resourceRequestMemory: "100Mi"
-                  resourceLimitMemory: "8192Mi"
-                - name: "jnlp"
-                  image: "{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}"
-                  command: "jenkins-slave"
-                  args: "^${computer.jnlpmac} ^${computer.name}"
-                  resourceRequestCpu: "50m"
-                  resourceLimitCpu: "500m"
-                  resourceRequestMemory: "400Mi"
-                  resourceLimitMemory: "1536Mi"
-                workspaceVolume:
-                  emptyDirWorkspaceVolume:
-                    memory: false
-                volumes:
-                - hostPathVolume:
-                    hostPath: "/var/run/docker.sock"
-                    mountPath: "/var/run/docker.sock"
-                - hostPathVolume:
-                    hostPath: "/var/data/jenkins_go_cache"
-                    mountPath: "/home/jenkins/go/pkg"
-                - hostPathVolume:
-                    hostPath: "/var/data/jenkins_sonar_cache"
-                    mountPath: "/root/.sonar/cache"
-                yaml: |
-                  spec:
-                    affinity:
-                      nodeAffinity:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                        - weight: 1
-                          preference:
-                            matchExpressions:
-                            - key: node-role.kubernetes.io/worker
-                              operator: In
-                              values:
-                              - ci
-                    tolerations:
-                    - key: "node.kubernetes.io/ci"
-                      operator: "Exists"
-                      effect: "NoSchedule"
-                    - key: "node.kubernetes.io/ci"
-                      operator: "Exists"
-                      effect: "PreferNoSchedule"
-                    containers:
-                    - name: "go"
-                      resources:
-                        requests:
-                          ephemeral-storage: "1Gi"
-                        limits:
-                          ephemeral-storage: "10Gi"
-                    securityContext:
-                      fsGroup: 1000
 
       securityRealm:
     {{- if eq .Values.securityRealm.type "ldap" }}

--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -364,7 +364,7 @@ data:
                           ephemeral-storage: "10Gi"
                     securityContext:
                       fsGroup: 1000
- 
+
       securityRealm:
     {{- if eq .Values.securityRealm.type "ldap" }}
         ldap:

--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -58,7 +58,35 @@ data:
                 - hostPathVolume:
                     hostPath: "/var/data/jenkins_sonar_cache"
                     mountPath: "/root/.sonar/cache"
-                yaml: "spec:\r\n  affinity:\r\n    nodeAffinity:\r\n      preferredDuringSchedulingIgnoredDuringExecution:\r\n      - weight: 1\r\n        preference:\r\n          matchExpressions:\r\n          - key: node-role.kubernetes.io/worker\r\n            operator: In\r\n            values:\r\n            - ci\r\n  tolerations:\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"NoSchedule\"\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"PreferNoSchedule\"\r\n  containers:\r\n  - name: \"base\"\r\n    resources:\r\n      requests:\r\n        ephemeral-storage: \"1Gi\"\r\n      limits:\r\n        ephemeral-storage: \"10Gi\"\r\n  securityContext:\r\n    fsGroup: 1000\r\n "
+                yaml: |
+                  spec:
+                    affinity:
+                      nodeAffinity:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 1
+                          preference:
+                            matchExpressions:
+                            - key: node-role.kubernetes.io/worker
+                              operator: In
+                              values:
+                              - ci
+                    tolerations:
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "NoSchedule"
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "PreferNoSchedule"
+                    containers:
+                    - name: "base"
+                      resources:
+                        requests:
+                          ephemeral-storage: "1Gi"
+                        limits:
+                          ephemeral-storage: "10Gi"
+                    securityContext:
+                      fsGroup: 1000
+
               - name: "nodejs"
                 namespace: "{{ .Values.Agent.WorkerNamespace }}"
                 label: "nodejs"
@@ -99,7 +127,35 @@ data:
                 - hostPathVolume:
                     hostPath: "/var/data/jenkins_sonar_cache"
                     mountPath: "/root/.sonar/cache"
-                yaml: "spec:\r\n  affinity:\r\n    nodeAffinity:\r\n      preferredDuringSchedulingIgnoredDuringExecution:\r\n      - weight: 1\r\n        preference:\r\n          matchExpressions:\r\n          - key: node-role.kubernetes.io/worker\r\n            operator: In\r\n            values:\r\n            - ci\r\n  tolerations:\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"NoSchedule\"\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"PreferNoSchedule\"\r\n  containers:\r\n  - name: \"nodejs\"\r\n    resources:\r\n      requests:\r\n        ephemeral-storage: \"1Gi\"\r\n      limits:\r\n        ephemeral-storage: \"10Gi\"\r\n  securityContext:\r\n    fsGroup: 1000\r\n "
+                yaml: |
+                  spec:
+                    affinity:
+                      nodeAffinity:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 1
+                          preference:
+                            matchExpressions:
+                            - key: node-role.kubernetes.io/worker
+                              operator: In
+                              values:
+                              - ci
+                    tolerations:
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "NoSchedule"
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "PreferNoSchedule"
+                    containers:
+                    - name: "nodejs"
+                      resources:
+                        requests:
+                          ephemeral-storage: "1Gi"
+                        limits:
+                          ephemeral-storage: "10Gi"
+                    securityContext:
+                      fsGroup: 1000
+                
               - name: "maven"
                 namespace: "{{ .Values.Agent.WorkerNamespace }}"
                 label: "maven"
@@ -137,7 +193,46 @@ data:
                 - hostPathVolume:
                     hostPath: "/var/data/jenkins_sonar_cache"
                     mountPath: "/root/.sonar/cache"
-                yaml: "spec:\r\n  affinity:\r\n    nodeAffinity:\r\n      preferredDuringSchedulingIgnoredDuringExecution:\r\n      - weight: 1\r\n        preference:\r\n          matchExpressions:\r\n          - key: node-role.kubernetes.io/worker\r\n            operator: In\r\n            values:\r\n            - ci\r\n  tolerations:\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"NoSchedule\"\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"PreferNoSchedule\"\r\n  containers:\r\n  - name: \"maven\"\r\n    resources:\r\n      requests:\r\n        ephemeral-storage: \"1Gi\"\r\n      limits:\r\n        ephemeral-storage: \"10Gi\"\r\n    volumeMounts:\r\n    - name: config-volume\r\n      mountPath: /opt/apache-maven-3.5.3/conf/settings.xml\r\n      subPath: settings.xml\r\n  volumes:\r\n    - name: config-volume\r\n      configMap:\r\n        name: ks-devops-agent\r\n        items:\r\n        - key: MavenSetting\r\n          path: settings.xml\r\n  securityContext:\r\n    fsGroup: 1000\r\n "
+                yaml: |
+                  spec:
+                    affinity:
+                      nodeAffinity:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 1
+                          preference:
+                            matchExpressions:
+                            - key: node-role.kubernetes.io/worker
+                              operator: In
+                              values:
+                              - ci
+                    tolerations:
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "NoSchedule"
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "PreferNoSchedule"
+                    containers:
+                    - name: "maven"
+                      resources:
+                        requests:
+                          ephemeral-storage: "1Gi"
+                        limits:
+                          ephemeral-storage: "10Gi"
+                      volumeMounts:
+                      - name: config-volume
+                        mountPath: /opt/apache-maven-3.5.3/conf/settings.xml
+                        subPath: settings.xml
+                    volumes:
+                      - name: config-volume
+                        configMap:
+                          name: ks-devops-agent
+                          items:
+                          - key: MavenSetting
+                            path: settings.xml
+                    securityContext:
+                      fsGroup: 1000
+                  
               - name: "go"
                 namespace: "{{ .Values.Agent.WorkerNamespace }}"
                 label: "go"
@@ -175,7 +270,35 @@ data:
                 - hostPathVolume:
                     hostPath: "/var/data/jenkins_sonar_cache"
                     mountPath: "/root/.sonar/cache"
-                yaml: "spec:\r\n  affinity:\r\n    nodeAffinity:\r\n      preferredDuringSchedulingIgnoredDuringExecution:\r\n      - weight: 1\r\n        preference:\r\n          matchExpressions:\r\n          - key: node-role.kubernetes.io/worker\r\n            operator: In\r\n            values:\r\n            - ci\r\n  tolerations:\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"NoSchedule\"\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"PreferNoSchedule\"\r\n  containers:\r\n  - name: \"go\"\r\n    resources:\r\n      requests:\r\n        ephemeral-storage: \"1Gi\"\r\n      limits:\r\n        ephemeral-storage: \"10Gi\"\r\n  securityContext:\r\n    fsGroup: 1000\r\n "
+                yaml: |
+                  spec:
+                    affinity:
+                      nodeAffinity:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 1
+                          preference:
+                            matchExpressions:
+                            - key: node-role.kubernetes.io/worker
+                              operator: In
+                              values:
+                              - ci
+                    tolerations:
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "NoSchedule"
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "PreferNoSchedule"
+                    containers:
+                    - name: "go"
+                      resources:
+                        requests:
+                          ephemeral-storage: "1Gi"
+                        limits:
+                          ephemeral-storage: "10Gi"
+                    securityContext:
+                      fsGroup: 1000
+ 
       securityRealm:
     {{- if eq .Values.securityRealm.type "ldap" }}
         ldap:


### PR DESCRIPTION
### What this PR dose?

Reformat yaml config item in pod template.

### Why we need it?

Before this, the yaml config items were formatted ugly, non-configurable and unreadable. But now, everything would be okay.

### How do I format them?

To open developer tools for your browser, please press `F12` and choose console tab. Then input JS code: `console.log("unformatted text")` and press `Enter`. Please see an example below:

![image](https://user-images.githubusercontent.com/16865714/138809036-749bc2b5-708e-46a4-9bc0-48e38478d37c.png)

/kind chore
