### PR TITLE
Add new DevOps agent for Golang 1.16

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -176,6 +176,73 @@ data:
                     hostPath: "/var/data/jenkins_sonar_cache"
                     mountPath: "/root/.sonar/cache"
                 yaml: "spec:\r\n  affinity:\r\n    nodeAffinity:\r\n      preferredDuringSchedulingIgnoredDuringExecution:\r\n      - weight: 1\r\n        preference:\r\n          matchExpressions:\r\n          - key: node-role.kubernetes.io/worker\r\n            operator: In\r\n            values:\r\n            - ci\r\n  tolerations:\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"NoSchedule\"\r\n  - key: \"node.kubernetes.io/ci\"\r\n    operator: \"Exists\"\r\n    effect: \"PreferNoSchedule\"\r\n  containers:\r\n  - name: \"go\"\r\n    resources:\r\n      requests:\r\n        ephemeral-storage: \"1Gi\"\r\n      limits:\r\n        ephemeral-storage: \"10Gi\"\r\n  securityContext:\r\n    fsGroup: 1000\r\n "
+
+              - name: "go16"
+                namespace: "{{ .Values.Agent.WorkerNamespace }}"
+                label: "go16"
+                nodeUsageMode: "EXCLUSIVE"
+                idleMinutes: 0
+                containers:
+                - name: "go"
+                  image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.golang16.image }}:{{ .Values.Agent.Builder.golang16.tag }}{{ template "jenkins.agent.variant" . }}"
+                  command: "cat"
+                  args: ""
+                  ttyEnabled: true
+                  privileged: {{ template "jenkins.agent.privileged" . }}
+                  resourceRequestCpu: "100m"
+                  resourceLimitCpu: "4000m"
+                  resourceRequestMemory: "100Mi"
+                  resourceLimitMemory: "8192Mi"
+                - name: "jnlp"
+                  image: "{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}"
+                  command: "jenkins-slave"
+                  args: "^${computer.jnlpmac} ^${computer.name}"
+                  resourceRequestCpu: "50m"
+                  resourceLimitCpu: "500m"
+                  resourceRequestMemory: "400Mi"
+                  resourceLimitMemory: "1536Mi"
+                workspaceVolume:
+                  emptyDirWorkspaceVolume:
+                    memory: false
+                volumes:
+                - hostPathVolume:
+                    hostPath: "/var/run/docker.sock"
+                    mountPath: "/var/run/docker.sock"
+                - hostPathVolume:
+                    hostPath: "/var/data/jenkins_go_cache"
+                    mountPath: "/home/jenkins/go/pkg"
+                - hostPathVolume:
+                    hostPath: "/var/data/jenkins_sonar_cache"
+                    mountPath: "/root/.sonar/cache"
+                yaml: |
+                  spec:
+                    affinity:
+                      nodeAffinity:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 1
+                          preference:
+                            matchExpressions:
+                            - key: node-role.kubernetes.io/worker
+                              operator: In
+                              values:
+                              - ci
+                    tolerations:
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "NoSchedule"
+                    - key: "node.kubernetes.io/ci"
+                      operator: "Exists"
+                      effect: "PreferNoSchedule"
+                    containers:
+                    - name: "go"
+                      resources:
+                        requests:
+                          ephemeral-storage: "1Gi"
+                        limits:
+                          ephemeral-storage: "10Gi"
+                    securityContext:
+                      fsGroup: 1000
+
       securityRealm:
     {{- if eq .Values.securityRealm.type "ldap" }}
         ldap:

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -427,6 +427,9 @@ Agent:
     Golang:
       Image: builder-go
       Tag: v3.1.0
+    golang16:
+      image: builder-go
+      tag: v3.2.0-alpha.01.16
     ContainerRuntime: docker # Available values: docker, podman
 
 Persistence:


### PR DESCRIPTION
### What this PR dose?

Add a new pod template for Golang 1.16.

### Why we need it?

Please see #28.

### Which issue dose this PR fix?

Fix #28 

### How to test?

1. Install ks-devops via helm charts

```bash
make install-chart
```

2. Create a test Pipeline

Pipeline script example:

```groovy
pipeline {
  agent {
    node {
      label 'go16'
    }
  }
  stages {
    stage('Greet') {
      steps {
        container('go') {
          sh '''go version'''
        }
      }
    }
  }
}
```