### PR TITLE
Bump chart version to 0.1.6

### DIFF
--- a/charts/ks-devops/Chart.yaml
+++ b/charts/ks-devops/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v3.2.0-rc.1
+appVersion: v3.2.0-rc.2
 
 dependencies:
   - name: jenkins

--- a/charts/ks-devops/Chart.yaml
+++ b/charts/ks-devops/Chart.yaml
@@ -20,7 +20,7 @@ version: 0.1.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v3.2.0-rc.2
+appVersion: v3.2.0
 
 dependencies:
   - name: jenkins

--- a/charts/ks-devops/charts/jenkins/Chart.yaml
+++ b/charts/ks-devops/charts/jenkins/Chart.yaml
@@ -1,4 +1,4 @@
-appVersion: 3.2.0-rc0-2.249.1
+appVersion: v3.2.0-2.249.1
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
   projects as well as arbitrary scripts.
@@ -13,4 +13,4 @@ name: jenkins
 sources:
 - https://github.com/jenkinsci/jenkins
 - https://github.com/jenkinsci/docker-jnlp-slave
-version: 0.19.1
+version: 0.19.2

--- a/charts/ks-devops/charts/s2i/Chart.yaml
+++ b/charts/ks-devops/charts/s2i/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.0
+version: 1.16.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
At the same time, bump the application version to v3.2.0-rc.2

See https://github.com/kubesphere/ks-devops/releases/tag/v3.2.0-rc.2

/cc @kubesphere-sigs/sig-devops 