### PR TITLE
Set the default jenkins image tag as master

### DIFF
--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -8,7 +8,7 @@ Master:
     SchedulerName: ""
   Name: jenkins-master
   Image: "kubespheredev/ks-jenkins"
-  ImageTag: "v3.2.0-2.249.1"
+  ImageTag: "master"
   ImagePullPolicy: "IfNotPresent"
   Component: "jenkins-master"
   UseSecurity: true


### PR DESCRIPTION
We already bumped the Jenkins core version from 2.249.1 to 2.319.1 in https://github.com/kubesphere/ks-jenkins/pull/61

It would be great to do more tests before we have the next release.

/cc @kubesphere-sigs/sig-devops 

The upstream PR is #20 