### PR TITLE
Avoid print too many gc log output

### DIFF
--- a/charts/ks-devops/charts/jenkins/README.md
+++ b/charts/ks-devops/charts/jenkins/README.md
@@ -303,3 +303,18 @@ Master:
     -Dhttps.proxyHost=192.168.64.1
     -Dhttps.proxyPort=3128
 ```
+
+## JVM troubleshooting
+
+You can add the following JVM parameters to the Jenkins if you want to get some troubleshooting information:
+
+```shell
+-verbose:gc
+-Xloggc:/var/jenkins_home/gc-%t.log
+-Xlog:gc
+-Xlog:gc*
+-Xlog:gc+heap=trace
+-Xlog:age*=trace
+-Xlog:ref*=debug
+-Xlog:ergo*=trace
+```

--- a/charts/ks-devops/charts/jenkins/values.yaml
+++ b/charts/ks-devops/charts/jenkins/values.yaml
@@ -36,14 +36,7 @@ Master:
     -Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000
     -Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true
     -Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=10000
-    -verbose:gc
-    -Xloggc:/var/jenkins_home/gc-%t.log
-    -Xlog:gc
-    -Xlog:gc*
-    -Xlog:gc+heap=trace
-    -Xlog:age*=trace
-    -Xlog:ref*=debug
-    -Xlog:ergo*=trace
+    -Djenkins.install.runSetupWizard=false
     -XX:+UseG1GC
     -XX:+UseStringDeduplication
     -XX:+ParallelRefProcEnabled


### PR DESCRIPTION
It is not necessary always to print the GC log information. I prefer to add those JVM parameters only when users meet problems.

See the description about `-Djenkins.install.runSetupWizard=false` from [here](https://github.com/jenkinsci/jenkins/blob/165d559469c7a58af581931bd1b89e5b9ed4a9af/core/src/main/java/jenkins/install/InstallUtil.java#L144).