### PR TITLE
Correct wrong image configuration on python agent

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -313,7 +313,7 @@ data:
                 idleMinutes: 0
                 containers:
                 - name: "python"
-                  image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.python.Image }}:{{ .Values.Agent.Builder.python.Tag }}{{ template "jenkins.agent.variant" . }}"
+                  image: "{{ .Values.Agent.Builder.Registry }}/{{ .Values.Agent.Builder.python.image }}:{{ .Values.Agent.Builder.python.tag }}{{ template "jenkins.agent.variant" . }}"
                   command: "cat"
                   args: ""
                   ttyEnabled: true


### PR DESCRIPTION
### What this PR dose

Correct wrong image configuration on python agent in `jenkins-casc-config.yml`.

### Why we need it

Correct builder image definition is right here:

https://github.com/kubesphere-sigs/ks-devops-helm-chart/blob/86b391c1c212c54a6005cb0a8713b8f2b676d9a7/charts/ks-devops/charts/jenkins/values.yaml#L421-L423

/kind bug