### PR TITLE
Override the default namespace of jwt cmd in the controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 charts/*.tgz
 .DS_Store
+.idea/

--- a/charts/ks-devops/templates/deployment-controller.yaml
+++ b/charts/ks-devops/templates/deployment-controller.yaml
@@ -39,6 +39,8 @@ spec:
             - /jwt
             - --output
             - configmap
+            - --namespace
+            - {{ .Release.Namespace }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
ks-devops be able to install in any namespace, so the default value must be overrided
