### PR TITLE
Change the default number of the Jenkins controller executors to 0

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -6,7 +6,7 @@ data:
   jenkins.yaml: |
     jenkins:
       mode: EXCLUSIVE
-      numExecutors: 5
+      numExecutors: 0
       scmCheckoutRetryCount: 2
       disableRememberMe: true
 


### PR DESCRIPTION
Build tasks should be assigned to separate build nodes. Due to the special deployment mode, the master node cannot bear the build environment capability.