### PR TITLE
Add event dispatcher configuration for pipeline event

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -413,6 +413,8 @@ data:
         server: "http://{{ include "ks-devops.apiserver-fullname" . }}.{{ .Release.Namespace }}:9090/"
         {{- end }}
         {{- end }}
+      eventDispatcher:
+        receiver: "http://{{ include "ks-devops.apiserver-fullname" . }}.{{ .Release.Namespace }}:9090/v1alpha3/webhooks/jenkins"
       gitLabServers:
         servers:
         - name: "https://gitlab.com"


### PR DESCRIPTION
### What this PR dose / Why we need it

Add event dispatcher configuration into Jenkins CasC for pipeline event plugin.

Please hold this PR before upstream PR below merged.

- https://github.com/kubesphere/ks-jenkins/pull/77

/hold