### PR TITLE
Add pre-defined templates

### DIFF
--- a/charts/ks-devops/templates/cluster-template-ci.yaml
+++ b/charts/ks-devops/templates/cluster-template-ci.yaml
@@ -1,0 +1,48 @@
+apiVersion: devops.kubesphere.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: ci
+  annotations:
+    devops.kubesphere.io/displayNameLocaleKey: CI
+    devops.kubesphere.io/discriptionLocaleKey: CI_DESC
+    devops.kubesphere.io/offcial: "true"
+spec:
+  template: |
+    pipeline {
+        agent {
+            node {
+              label 'base'
+            }
+        }
+        environment {
+            DOCKER_CREDENTIAL_ID = 'dockerhub'
+            KUBECONFIG_CREDENTIAL_ID = 'kubeconfig'
+            REGISTRY = 'docker.io'
+            DOCKERHUB_NAMESPACE = 'shaowenchen'
+            APP_NAME = 'devops-python-sample'
+            SONAR_CREDENTIAL_ID = 'sonar-token'
+        }
+        parameters {
+            string(name: 'BRANCH_NAME', defaultValue: 'master', description: '')
+        }
+        stages {
+            stage('clone code') {
+                steps {
+                    container('base') {
+                        checkout([$class: 'GitSCM', branches: [[name: '*/$BRANCH_NAME']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/kubesphere/devops-python-sample.git']]])
+                    }
+                }
+            }
+            stage('build & push') {
+                steps {
+                    container('base') {
+                        withCredentials([usernamePassword(credentialsId : "$DOCKER_CREDENTIAL_ID" ,passwordVariable: 'DOCKER_PASSWORD' ,usernameVariable: 'DOCKER_USERNAME' ,)]) {
+                            sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'
+                            sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:$BUILD_NUMBER .'
+                            sh 'docker push $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:$BUILD_NUMBER'
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/charts/ks-devops/templates/cluster-template-ci.yaml
+++ b/charts/ks-devops/templates/cluster-template-ci.yaml
@@ -3,8 +3,13 @@ kind: ClusterTemplate
 metadata:
   name: ci
   annotations:
-    devops.kubesphere.io/displayNameLocaleKey: CI
-    devops.kubesphere.io/discriptionLocaleKey: CI_DESC
+    devops.kubesphere.io/displayNameEN: &defaultDisplayName "Continuous Integration (CI)"
+    devops.kubesphere.io/displayNameZH: "持续集成 (CI)"
+    devops.kubesphere.io/discriptionEN: &defaultDescription "Continuous integration (CI) is the process of automatically detecting, pulling, building, and (in most cases) unit testing after source code changes."
+    devops.kubesphere.io/discriptionZH: "持续集成（CI）是在源代码变更后自动检测、拉取、构建和（在大多数情况下）进行单元测试的过程。"
+    devops.kubesphere.io/displayName: *defaultDisplayName
+    devops.kubesphere.io/description: *defaultDescription
+  labels:
     devops.kubesphere.io/offcial: "true"
 spec:
   template: |

--- a/charts/ks-devops/templates/cluster-template-cicd.yaml
+++ b/charts/ks-devops/templates/cluster-template-cicd.yaml
@@ -1,0 +1,80 @@
+apiVersion: devops.kubesphere.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: cicd
+  annotations:
+    devops.kubesphere.io/displayNameLocaleKey: CICD
+    devops.kubesphere.io/descriptionLocaleKey: CICD_DESC
+    devops.kubesphere.io/offcial: "true"
+spec:
+  template: |
+    pipeline {
+        agent {
+          node {
+            label 'maven'
+          }
+        }
+        parameters {
+            string(name:'TAG_NAME',defaultValue: '',description:'')
+        }
+        environment {
+            DOCKER_CREDENTIAL_ID = 'dockerhub-id'
+            GITHUB_CREDENTIAL_ID = 'github-id'
+            KUBECONFIG_CREDENTIAL_ID = 'demo-kubeconfig'
+            REGISTRY = 'docker.io'
+            DOCKERHUB_NAMESPACE = 'docker_username'
+            GITHUB_ACCOUNT = 'kubesphere'
+            APP_NAME = 'devops-java-sample'
+        }
+        stages {
+            stage('clone code') {
+                steps {
+                    container('base') {
+                      checkout([$class: 'GitSCM', branches: [[name: '*/$BRANCH_NAME']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/kubesphere/devops-python-sample.git']]])
+                    }
+                }
+            }
+            stage ('unit test') {
+                steps {
+                    container ('maven') {
+                        sh 'mvn clean -o -gs \`pwd\`/configuration/settings.xml test'
+                    }
+                }
+            }
+            stage ('build & push') {
+                steps {
+                    container ('maven') {
+                        sh 'mvn -o -Dmaven.test.skip=true -gs \`pwd\`/configuration/settings.xml clean package'
+                        sh 'docker build -f Dockerfile-online -t $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER .'
+                        withCredentials([usernamePassword(passwordVariable : 'DOCKER_PASSWORD' ,usernameVariable : 'DOCKER_USERNAME' ,credentialsId : "$DOCKER_CREDENTIAL_ID" ,)]) {
+                            sh 'echo "$DOCKER_PASSWORD" | docker login $REGISTRY -u "$DOCKER_USERNAME" --password-stdin'
+                            sh 'docker push  $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER'
+                        }
+                    }
+                }
+            }
+            stage('push latest'){
+                when{
+                    branch 'master'
+                }
+                steps{
+                     container ('maven') {
+                         sh 'docker tag  $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:latest '
+                         sh 'docker push  $REGISTRY/$DOCKERHUB_NAMESPACE/$APP_NAME:latest '
+                     }
+                }
+            }
+            stage('deploy to dev') {
+                steps {
+                    input(id: 'deploy-to-dev', message: 'deploy to dev?')
+                    kubernetesDeploy(configs: 'deploy/dev-ol/**', enableConfigSubstitution: true, kubeconfigId: "$KUBECONFIG_CREDENTIAL_ID")
+                }
+            }
+            stage('deploy to production') {
+                steps {
+                    input(id: 'deploy-to-production', message: 'deploy to production?')
+                    kubernetesDeploy(configs: 'deploy/prod-ol/**', enableConfigSubstitution: true, kubeconfigId: "$KUBECONFIG_CREDENTIAL_ID")
+                }
+            }
+        }
+    }

--- a/charts/ks-devops/templates/cluster-template-cicd.yaml
+++ b/charts/ks-devops/templates/cluster-template-cicd.yaml
@@ -3,8 +3,13 @@ kind: ClusterTemplate
 metadata:
   name: cicd
   annotations:
-    devops.kubesphere.io/displayNameLocaleKey: CICD
-    devops.kubesphere.io/descriptionLocaleKey: CICD_DESC
+    devops.kubesphere.io/displayNameEN: &defaultDisplayName "Continuous Integration & Delivery (CI/CD)"
+    devops.kubesphere.io/displayNameZH: "持续集成&交付 (CI/CD)"
+    devops.kubesphere.io/descriptionEN: &defaultDescription "Continuous deployment (CD) refers to the idea of automatically providing the release version in the continuous delivery pipeline to end users. According to the user\'s installation method, automatic deployment in the cloud environment, app upgrades (such as apps on mobile phones), website updates, or only the list of available versions."
+    devops.kubesphere.io/descriptionZH: "持续部署（CD）是指能够自动提供持续交付管道中发布版本给最终用户使用的想法。根据用户的安装方式，在云环境中自动部署、app 升级（如手机上的应用程序）、更新网站或只更新可用版本列表。"
+    devops.kubesphere.io/displayName: *defaultDisplayName
+    devops.kubesphere.io/description: *defaultDescription
+  labels:
     devops.kubesphere.io/offcial: "true"
 spec:
   template: |


### PR DESCRIPTION
### What this PR dose

According to https://github.com/kubesphere/console/blob/a482ed8fc4e84231976fef19506ef2bbc6c30da6/src/pages/devops/components/Pipeline/PipelineTemplate/templePipeline.js, I moved them as ClusterTemplate resources.

- **Upstream PR**: #56

You can see the two templates after executing `make install-chart`:

```bash
    ~  kubectl get clustertemplates -oname                                                                                            ✔  kind-kind ⎈ 
clustertemplate.devops.kubesphere.io/ci
clustertemplate.devops.kubesphere.io/cicd
```

/kind chore