### PR TITLE
Prepend 'http://' for 'unclassified.location.url' in CasC configuration

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-casc-config.yml
@@ -400,7 +400,7 @@ data:
 
     unclassified:
       location:
-        url: {{ .Values.Master.HostName }}
+        url: "http://{{ .Values.Master.HostName }}"
       kubespheretokenauthglobalconfiguration:
         cacheConfiguration:
           size: 20


### PR DESCRIPTION
Fix: https://github.com/kubesphere/ks-devops/issues/440