### PR TITLE
Fetch cluster templates from kubesphere-sigs/pipeline-templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,5 @@ load-images-to-k3d:
 
 fetch-crds:
 	./hack/fetch-crds.sh
+fetch-templates:
+	./hack/fetch-templates.sh

--- a/charts/ks-devops/templates/golang.yaml
+++ b/charts/ks-devops/templates/golang.yaml
@@ -1,0 +1,88 @@
+apiVersion: devops.kubesphere.io/v1alpha3
+kind: ClusterTemplate
+metadata:
+  name: golang
+  annotations:
+    devops.kubesphere.io/displayNameEN: "Golang"
+    devops.kubesphere.io/displayNameZH: "Golang"
+    devops.kubesphere.io/descriptionEN: "Designed for the continuous integration of most Golang projects, including dependency downloading, testing, building, and artifact archiving."
+    devops.kubesphere.io/descriptionZH: "专为大多数 Golang 项目的持续集成而设计，包括依赖下载、测试、构建和归档。"
+    devops.kubesphere.io/icon: "golang.svg"
+spec:
+  parameters:
+    - name: CloneURL
+      description: The URL you want to clone
+      required: true
+      default: https://github.com/johnniang/go-sample
+    - name: CloneRevision
+      description: Which revision you want to checkout from
+      required: true
+      default: main
+    - name: GolangDockerImage
+      description: Docker image of Golang. Refer to https://hub.docker.com/_/golang
+      default: "golang:1.17"
+      required: true
+    - name: DependencyDownloadScript
+      description: Shell script for depedency download.
+      default: "go mod download"
+      required: true
+    - name: TestScript
+      description: Shell script for testing.
+      default: "go test ./..."
+      required: true
+    - name: BuildScript
+      description: Shell script for building.
+      default: "go build -o service ./..."
+      required: true
+    - name: ArtifactsLocation
+      description: Artifacts location. e.g. service or dist/.
+      default: "service"
+      required: true
+
+  template: |
+    pipeline {
+      agent {
+        kubernetes {
+          inheritFrom 'go'
+          containerTemplate {
+            name 'go'
+            image '$(.params.GolangDockerImage)'
+          }
+        }
+      }
+      stages {
+        stage('Clone repository') {
+          steps {
+            checkout([$class: 'GitSCM', branches: [[name: '$(.params.CloneRevision)']], 
+                extensions: [[$class: 'CloneOption', depth: 1, shallow: true]], userRemoteConfigs: [[url: '$(.params.CloneURL)']]
+            ])
+          }
+        }
+        stage('Download dependencies') {
+          steps {
+            container('go') {
+              sh '''$(.params.DependencyDownloadScript)'''
+            }
+          }
+        }
+        stage('Run test') {
+          steps {
+            container('go') {
+              sh '''$(.params.TestScript)'''
+            }
+          }
+        }
+        stage('Run build') {
+          steps {
+            container('go') {
+              sh '''$(.params.BuildScript)'''
+            }
+          }
+        }
+        stage('Archive artifacts') {
+          steps {
+            archiveArtifacts '$(.params.ArtifactsLocation)'
+          }
+        }
+      }
+    }

--- a/charts/ks-devops/templates/nodejs.yaml
+++ b/charts/ks-devops/templates/nodejs.yaml
@@ -1,0 +1,91 @@
+apiVersion: devops.kubesphere.io/v1alpha3
+kind: ClusterTemplate
+metadata:
+  name: nodejs
+  annotations:
+    devops.kubesphere.io/displayNameEN: "Node.js"
+    devops.kubesphere.io/displayNameZH: "Node.js"
+    devops.kubesphere.io/descriptionEN: "Designed for the continuous integration of most Node.js projects, including dependency downloading, testing, building, and artifact archiving."
+    devops.kubesphere.io/descriptionZH: "专为大多数 Node.js 项目的持续集成而设计，包括依赖下载、测试、构建和归档。"
+    devops.kubesphere.io/icon: "nodejs.svg"
+spec:
+  parameters:
+    - name: CloneURL
+      description: The URL you want to clone.
+      required: true
+      default: https://github.com/johnniang/vue-sample
+    - name: CloneRevision
+      description: Which revision you want to checkout from.
+      required: true
+      default: main
+    - name: NodeDockerImage
+      description: Docker image of node. Refer to https://hub.docker.com/_/node.
+      default: "node:14.19.0"
+      required: true
+    - name: InstallScript
+      description: Shell script to install dependencies.
+      required: true
+      default: "npm install"
+    - name: TestScript
+      description: Shell script to test project.
+      required: true
+      default: "npm run test"
+    - name: BuildScript
+      description: Shell script to build project.
+      required: true
+      default: "npm run build"
+    - name: ArtifactsPath
+      description: The path of artifacts.
+      required: false
+      default: "dist/"
+  template: |
+    pipeline {
+      agent {
+        kubernetes {
+          inheritFrom 'nodejs base'
+          containerTemplate {
+            name 'nodejs'
+            image '$(.params.NodeDockerImage)'
+          }
+        }
+      }
+      stages {
+        stage('Clone repository') {
+          agent none
+          steps {
+            checkout([$class: 'GitSCM', branches: [[name: '$(.params.CloneRevision)']], 
+                extensions: [[$class: 'CloneOption', depth: 1, shallow: true]], userRemoteConfigs: [[url: '$(.params.CloneURL)']]
+            ])
+          }
+        }
+        stage('Run npm install') {
+          steps {
+            container('nodejs') {
+              sh '$(.params.InstallScript)'
+            }
+          }
+        }
+        stage('Run test') {
+          steps {
+            container('nodejs') {
+              sh '$(.params.TestScript)'
+            }
+          }
+        }
+        stage('Run build') {
+          steps {
+            container('nodejs') {
+              sh '$(.params.BuildScript)'
+            }
+          }
+        }
+        stage('Archive artifacts') {
+          steps {
+            container('base') {
+              sh 'zip -r dist.zip $(.params.ArtifactsPath)'
+            }
+            archiveArtifacts 'dist.zip'
+          }
+        }
+      }
+    }

--- a/hack/fetch-templates.sh
+++ b/hack/fetch-templates.sh
@@ -1,0 +1,13 @@
+set -o errexit
+set -o nounset
+set -o pipefail
+
+temp_dir=$(mktemp -d -t pipeline-templates-XXXXX)
+target_dir="charts/ks-devops/templates"
+git clone --depth 1 https://ghproxy.com/https://github.com/kubesphere-sigs/pipeline-templates $temp_dir
+for template in $(find $temp_dir/featured -type f \( -name "*.yml" -o -name "*.yaml" \) -print)
+do
+  echo "Copying $template into $target_dir"
+  cp $template $target_dir
+done
+rm $temp_dir -rf


### PR DESCRIPTION
### What this PR does

As mentioned in title.

After that, we could execute `make fetch-templates` command to fetch cluster templates from https://github.com/kubesphere-sigs/pipeline-templates.

/kind chore
/cc @kubesphere-sigs/sig-devops 