### PR TITLE
Rename cluster template files and deprecated ci and cicd templates

### DIFF
--- a/charts/ks-devops/templates/cluster-template-ci.yaml
+++ b/charts/ks-devops/templates/cluster-template-ci.yaml
@@ -6,7 +6,7 @@ metadata:
     devops.kubesphere.io/displayNameEN: &defaultDisplayName "Continuous Integration (CI)"
     devops.kubesphere.io/displayNameZH: "持续集成 (CI)"
     devops.kubesphere.io/descriptionEN: &defaultDescription "[Deprecated] Continuous integration (CI) is the process of automatically detecting, pulling, building, and (in most cases) unit testing after source code changes."
-    devops.kubesphere.io/descriptionZH: "【已过期】持续集成（CI）是在源代码变更后自动检测、拉取、构建和（在大多数情况下）进行单元测试的过程。"
+    devops.kubesphere.io/descriptionZH: "【已弃用】持续集成（CI）是在源代码变更后自动检测、拉取、构建和（在大多数情况下）进行单元测试的过程。"
     devops.kubesphere.io/icon: "ci-temple-en.svg"
 spec:
   template: |

--- a/charts/ks-devops/templates/cluster-template-ci.yaml
+++ b/charts/ks-devops/templates/cluster-template-ci.yaml
@@ -5,12 +5,9 @@ metadata:
   annotations:
     devops.kubesphere.io/displayNameEN: &defaultDisplayName "Continuous Integration (CI)"
     devops.kubesphere.io/displayNameZH: "持续集成 (CI)"
-    devops.kubesphere.io/descriptionEN: &defaultDescription "Continuous integration (CI) is the process of automatically detecting, pulling, building, and (in most cases) unit testing after source code changes."
-    devops.kubesphere.io/descriptionZH: "持续集成（CI）是在源代码变更后自动检测、拉取、构建和（在大多数情况下）进行单元测试的过程。"
-    devops.kubesphere.io/displayName: *defaultDisplayName
-    devops.kubesphere.io/description: *defaultDescription
-  labels:
-    devops.kubesphere.io/offcial: "true"
+    devops.kubesphere.io/descriptionEN: &defaultDescription "[Deprecated] Continuous integration (CI) is the process of automatically detecting, pulling, building, and (in most cases) unit testing after source code changes."
+    devops.kubesphere.io/descriptionZH: "【已过期】持续集成（CI）是在源代码变更后自动检测、拉取、构建和（在大多数情况下）进行单元测试的过程。"
+    devops.kubesphere.io/icon: "ci-temple-en.svg"
 spec:
   template: |
     pipeline {

--- a/charts/ks-devops/templates/cluster-template-cicd.yaml
+++ b/charts/ks-devops/templates/cluster-template-cicd.yaml
@@ -6,7 +6,7 @@ metadata:
     devops.kubesphere.io/displayNameEN: "Continuous Integration & Delivery (CI/CD)"
     devops.kubesphere.io/displayNameZH: "持续集成&交付 (CI/CD)"
     devops.kubesphere.io/descriptionEN: "[Deprecated] Continuous deployment (CD) refers to the idea of automatically providing the release version in the continuous delivery pipeline to end users. According to the user\'s installation method, automatic deployment in the cloud environment, app upgrades (such as apps on mobile phones), website updates, or only the list of available versions."
-    devops.kubesphere.io/descriptionZH: "【已过期】持续部署（CD）是指能够自动提供持续交付管道中发布版本给最终用户使用的想法。根据用户的安装方式，在云环境中自动部署、app 升级（如手机上的应用程序）、更新网站或只更新可用版本列表。"
+    devops.kubesphere.io/descriptionZH: "【已弃用】持续部署（CD）是指能够自动提供持续交付管道中发布版本给最终用户使用的想法。根据用户的安装方式，在云环境中自动部署、app 升级（如手机上的应用程序）、更新网站或只更新可用版本列表。"
     devops.kubesphere.io/icon: "cicd-temple-en.svg"
 spec:
   template: |

--- a/charts/ks-devops/templates/cluster-template-cicd.yaml
+++ b/charts/ks-devops/templates/cluster-template-cicd.yaml
@@ -3,14 +3,11 @@ kind: ClusterTemplate
 metadata:
   name: cicd
   annotations:
-    devops.kubesphere.io/displayNameEN: &defaultDisplayName "Continuous Integration & Delivery (CI/CD)"
+    devops.kubesphere.io/displayNameEN: "Continuous Integration & Delivery (CI/CD)"
     devops.kubesphere.io/displayNameZH: "持续集成&交付 (CI/CD)"
-    devops.kubesphere.io/descriptionEN: &defaultDescription "Continuous deployment (CD) refers to the idea of automatically providing the release version in the continuous delivery pipeline to end users. According to the user\'s installation method, automatic deployment in the cloud environment, app upgrades (such as apps on mobile phones), website updates, or only the list of available versions."
-    devops.kubesphere.io/descriptionZH: "持续部署（CD）是指能够自动提供持续交付管道中发布版本给最终用户使用的想法。根据用户的安装方式，在云环境中自动部署、app 升级（如手机上的应用程序）、更新网站或只更新可用版本列表。"
-    devops.kubesphere.io/displayName: *defaultDisplayName
-    devops.kubesphere.io/description: *defaultDescription
-  labels:
-    devops.kubesphere.io/offcial: "true"
+    devops.kubesphere.io/descriptionEN: "[Deprecated] Continuous deployment (CD) refers to the idea of automatically providing the release version in the continuous delivery pipeline to end users. According to the user\'s installation method, automatic deployment in the cloud environment, app upgrades (such as apps on mobile phones), website updates, or only the list of available versions."
+    devops.kubesphere.io/descriptionZH: "【已过期】持续部署（CD）是指能够自动提供持续交付管道中发布版本给最终用户使用的想法。根据用户的安装方式，在云环境中自动部署、app 升级（如手机上的应用程序）、更新网站或只更新可用版本列表。"
+    devops.kubesphere.io/icon: "cicd-temple-en.svg"
 spec:
   template: |
     pipeline {

--- a/charts/ks-devops/templates/cluster-template-golang.yaml
+++ b/charts/ks-devops/templates/cluster-template-golang.yaml
@@ -10,14 +10,14 @@ metadata:
     devops.kubesphere.io/icon: "golang.svg"
 spec:
   parameters:
-    - name: CloneURL
+    - name: GitRepository
       description: The URL you want to clone
       required: true
-      default: https://github.com/johnniang/go-sample
-    - name: CloneRevision
+      default: https://github.com/kubesphere-sigs/demo-go-http
+    - name: GitRevision
       description: Which revision you want to checkout from
       required: true
-      default: main
+      default: master
     - name: GolangDockerImage
       description: Docker image of Golang. Refer to https://hub.docker.com/_/golang
       default: "golang:1.17"
@@ -32,10 +32,10 @@ spec:
       required: true
     - name: BuildScript
       description: Shell script for building.
-      default: "go build -o service ./..."
+      default: "go build -o service main.go"
       required: true
     - name: ArtifactsLocation
-      description: Artifacts location. e.g. service or dist/.
+      description: Artifacts location. e.g. service or build/.
       default: "service"
       required: true
 
@@ -53,8 +53,8 @@ spec:
       stages {
         stage('Clone repository') {
           steps {
-            checkout([$class: 'GitSCM', branches: [[name: '$(.params.CloneRevision)']], 
-                extensions: [[$class: 'CloneOption', depth: 1, shallow: true]], userRemoteConfigs: [[url: '$(.params.CloneURL)']]
+            checkout([$class: 'GitSCM', branches: [[name: '$(.params.GitRevision)']], 
+                extensions: [[$class: 'CloneOption', depth: 1, shallow: true]], userRemoteConfigs: [[url: '$(.params.GitRepository)']]
             ])
           }
         }

--- a/charts/ks-devops/templates/cluster-template-maven.yaml
+++ b/charts/ks-devops/templates/cluster-template-maven.yaml
@@ -1,0 +1,88 @@
+apiVersion: devops.kubesphere.io/v1alpha3
+kind: ClusterTemplate
+metadata:
+  name: maven
+  annotations:
+    devops.kubesphere.io/displayNameEN: "Maven"
+    devops.kubesphere.io/displayNameZH: "Maven"
+    devops.kubesphere.io/descriptionEN: "Designed for the continuous integration of most Maven projects, including dependency downloading, testing, building, and artifact archiving."
+    devops.kubesphere.io/descriptionZH: "专为大多数 Maven 项目的持续集成而设计，包括依赖下载、测试、构建和归档。"
+    devops.kubesphere.io/icon: "maven.svg"
+spec:
+  parameters:
+    - name: GitRepository
+      description: The Git repository you want to clone
+      required: true
+      default: https://github.com/kubesphere-sigs/demo-java
+    - name: GitRevision
+      description: Which revision you want to checkout from
+      required: true
+      default: master
+    - name: MavenDockerImage
+      description: Docker image of Maven. Refer to https://hub.docker.com/_/maven
+      default: "maven:3.8.4-jdk-11"
+      required: true
+    - name: CompileScript
+      description: Shell script for depedency download and compile.
+      default: "mvn compile"
+      required: true
+    - name: TestScript
+      description: Shell script for testing.
+      default: "mvn clean test"
+      required: true
+    - name: BuildScript
+      description: Shell script for building.
+      default: "mvn package"
+      required: true
+    - name: ArtifactsLocation
+      description: Artifacts location. e.g. target/demo-java-1.0.0.jar or target/*.jar.
+      default: "target/*.jar"
+      required: true
+
+  template: |
+    pipeline {
+      agent {
+        kubernetes {
+          inheritFrom 'maven'
+          containerTemplate {
+            name 'maven'
+            image '$(.params.MavenDockerImage)'
+          }
+        }
+      }
+      stages {
+        stage('Clone repository') {
+          steps {
+            checkout([$class: 'GitSCM', branches: [[name: '$(.params.GitRevision)']], 
+                extensions: [[$class: 'CloneOption', depth: 1, shallow: true]], userRemoteConfigs: [[url: '$(.params.GitRepository)']]
+            ])
+          }
+        }
+        stage('Run compile') {
+          steps {
+            container('maven') {
+              sh '''$(.params.CompileScript)'''
+            }
+          }
+        }
+        stage('Run test') {
+          steps {
+            container('maven') {
+              sh '''$(.params.TestScript)'''
+            }
+          }
+        }
+        stage('Run build') {
+          steps {
+            container('maven') {
+              sh '''$(.params.BuildScript)'''
+            }
+          }
+        }
+        stage('Archive artifacts') {
+          steps {
+            archiveArtifacts '$(.params.ArtifactsLocation)'
+          }
+        }
+      }
+    }

--- a/charts/ks-devops/templates/cluster-template-nodejs.yaml
+++ b/charts/ks-devops/templates/cluster-template-nodejs.yaml
@@ -10,14 +10,14 @@ metadata:
     devops.kubesphere.io/icon: "nodejs.svg"
 spec:
   parameters:
-    - name: CloneURL
+    - name: GitURL
       description: The URL you want to clone.
       required: true
-      default: https://github.com/johnniang/vue-sample
-    - name: CloneRevision
+      default: https://github.com/kubesphere-sigs/demo-javascript
+    - name: GitRevision
       description: Which revision you want to checkout from.
       required: true
-      default: main
+      default: master
     - name: NodeDockerImage
       description: Docker image of node. Refer to https://hub.docker.com/_/node.
       default: "node:14.19.0"
@@ -53,8 +53,8 @@ spec:
         stage('Clone repository') {
           agent none
           steps {
-            checkout([$class: 'GitSCM', branches: [[name: '$(.params.CloneRevision)']], 
-                extensions: [[$class: 'CloneOption', depth: 1, shallow: true]], userRemoteConfigs: [[url: '$(.params.CloneURL)']]
+            checkout([$class: 'GitSCM', branches: [[name: '$(.params.GitRevision)']], 
+                extensions: [[$class: 'CloneOption', depth: 1, shallow: true]], userRemoteConfigs: [[url: '$(.params.GitURL)']]
             ])
           }
         }

--- a/hack/fetch-templates.sh
+++ b/hack/fetch-templates.sh
@@ -8,6 +8,6 @@ git clone --depth 1 https://ghproxy.com/https://github.com/kubesphere-sigs/pipel
 for template in $(find $temp_dir/featured -type f \( -name "*.yml" -o -name "*.yaml" \) -print)
 do
   echo "Copying $template into $target_dir"
-  cp $template $target_dir
+  cp $template "$target_dir/cluster-template-$(basename $template)"
 done
 rm $temp_dir -rf


### PR DESCRIPTION
### What this PR does

1. Add prefix `cluster-template-` to template files
2. Deprecated `ci` and `cicd` templates
3. Fetch latest templates using `fetch-templates.sh` from https://github.com/kubesphere-sigs/pipeline-templates.

/kind optimization
/cc @kubesphere-sigs/sig-devops 