### PR TITLE
Update the clusterrole setting of the devops

### DIFF
--- a/charts/ks-devops/templates/serviceaccount.yaml
+++ b/charts/ks-devops/templates/serviceaccount.yaml
@@ -19,66 +19,299 @@ metadata:
   labels:
     {{- include "ks-devops.labels" . | nindent 4 }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - apps
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - extensions
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - batch
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - devops.kubesphere.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - autoscaling
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - appprojects
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - argoproj.io
+  resources:
+  - argocds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - cluster.kubesphere.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - addonStrategies
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - addons
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - addonstrategies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - clustertemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - clustertemplates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - devopsprojects
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - gitrepositories
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - pipelineruns
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - pipelineruns/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - pipelines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - pipelines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - releasercontrollers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2ibinaries
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2ibuilders
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2ibuildertemplates
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - s2iruns
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - templates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - templates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - devops.kubesphere.io
+  resources:
+  - webhooks
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gitops.kubesphere.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - gitops.kubesphere.io
+  resources:
+  - applications/status
+  verbs:
+  - get
+  - update
 
 ---
 kind: ClusterRoleBinding

--- a/charts/ks-devops/templates/serviceaccount.yaml
+++ b/charts/ks-devops/templates/serviceaccount.yaml
@@ -33,6 +33,7 @@ rules:
   resources:
   - events
   verbs:
+  - create
   - patch
 - apiGroups:
   - ""


### PR DESCRIPTION
Currently, the clusterRole has too much permission. This is not right.

This content was copied from [here](https://github.com/kubesphere/ks-devops/blob/master/config/rbac/role.yaml).