### PR TITLE
Add a role and rolebinding for the Jenkins worker

### DIFF
--- a/charts/ks-devops/charts/jenkins/templates/jenkins-worker-rbac.yaml
+++ b/charts/ks-devops/charts/jenkins/templates/jenkins-worker-rbac.yaml
@@ -1,0 +1,30 @@
+{{- $jenkinsName := include "jenkins.fullname" . -}}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $jenkinsName }}-worker-role
+  namespace: {{ .Values.Agent.WorkerNamespace }}
+rules:
+- apiGroups:
+  - gitops.kubesphere.io
+  resources:
+  - applications
+  verbs:
+  - get
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $jenkinsName }}-worker-role-binding
+  namespace: {{ .Values.Agent.WorkerNamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Values.Agent.WorkerNamespace }}
+roleRef:
+  kind: Role
+  name: {{ $jenkinsName }}-worker-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
the command ks which located in the base container needs the permission to get applications.gitops.kubesphere.io

See the following error output:
```
cannot find application 'testq2szm/demo-go-http', error is: applications.gitops.kubesphere.io "demo-go-http" is forbidden: User "system:serviceaccount:kubesphere-devops-worker:default" cannot get resource "applications" in API group "gitops.kubesphere.io" in the namespace "testq2szm"
```

see more details about the command: `ks app update` from [here](https://github.com/kubesphere-sigs/ks/pull/256).