### PR TITLE
bugfix: CronJob apiVersion:batch/v1 is not compatible with k8s-1.20

### DIFF
--- a/charts/ks-devops/templates/_helpers.tpl
+++ b/charts/ks-devops/templates/_helpers.tpl
@@ -94,3 +94,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+setup CronJob apiversion by k8s version
+*/}}
+{{- define "cronjob.apiversion" -}}
+{{- if semverCompare ">=1.24.0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "batch/v1" -}}
+{{- else }}
+{{- print "batch/v1beta1" -}}
+{{- end }}
+{{- end }}

--- a/charts/ks-devops/templates/cronjob-gc.yaml
+++ b/charts/ks-devops/templates/cronjob-gc.yaml
@@ -1,5 +1,5 @@
-apiVersion: batch/v1
 kind: CronJob
+apiVersion: {{ template "cronjob.apiversion" . }}
 metadata:
   name: {{ include "ks-devops.fullname" . }}
   labels:


### PR DESCRIPTION
Bugfix: CronJob apiVersion:batch/v1 is not compatible with k8s-1.20, dynamic setting up CronJob apiVersion by KubeVersion.